### PR TITLE
`golangci-lint` fails to run due to `revive`s unknown `time-equal` rule

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -198,7 +198,6 @@ linters-settings:
       - name: string-of-int
         severity: error
       - name: superfluous-else
-      - name: time-equal
       - name: time-naming
       - name: unconditional-recursion
       - name: unexported-naming


### PR DESCRIPTION
Fixes #76 